### PR TITLE
Restrict File Permissions on Uploaded Files

### DIFF
--- a/exif.py
+++ b/exif.py
@@ -28,6 +28,7 @@ from utils.upload_utils import (
     ZIP_SIZE_LIMIT_MB,
 )
 from utils.mongo_utils import create_mongo_client, create_db, create_collection, close_connection
+from utils.file_permissions import restrict_file_permissions
 
 
 load_dotenv()
@@ -127,6 +128,9 @@ def handle_upload():
 
         log.info(f"request {req_id}: unzipping images")
         unzip_file(zip_path, imgs_folder)
+
+        log.info(f"request {req_id}: restricting execute permissions")
+        restrict_file_permissions(imgs_folder)
 
         log.info(f"request {req_id}: extracting image metadata")
         extract_metadata(imgs_folder)

--- a/test/unit/test_file_permissions.py
+++ b/test/unit/test_file_permissions.py
@@ -1,3 +1,8 @@
+"""
+Unit tests for utils.file_permissions.py
+"""
+
+
 import pytest
 import os
 import shutil

--- a/test/unit/test_file_permissions.py
+++ b/test/unit/test_file_permissions.py
@@ -1,0 +1,25 @@
+import pytest
+import os
+import shutil
+
+from utils.file_permissions import restrict_file_permissions
+from test.testing_utils import create_mixed_files
+
+
+TEST_FOLDER = os.path.join("test", "unit", "test_file_perm")
+
+
+def test_restrict_file_permissions():
+    """
+    Tests that restrict_folder_permissions() sets the correct permissions on a folder.
+    """
+    os.mkdir(TEST_FOLDER)
+    create_mixed_files(2, TEST_FOLDER)
+    try:
+        restrict_file_permissions(TEST_FOLDER)
+        for file in os.listdir(TEST_FOLDER):
+            file_path = os.path.join(TEST_FOLDER, file)
+            assert oct(os.stat(file_path).st_mode)[-3:] == "644"
+    finally:
+        shutil.rmtree(TEST_FOLDER)
+        pass

--- a/test/unit/test_file_permissions.py
+++ b/test/unit/test_file_permissions.py
@@ -7,6 +7,7 @@ from test.testing_utils import create_mixed_files
 
 
 TEST_FOLDER = os.path.join("test", "unit", "test_file_perm")
+EXPECTED_PERM = "644"
 
 
 def test_restrict_file_permissions():
@@ -19,7 +20,7 @@ def test_restrict_file_permissions():
         restrict_file_permissions(TEST_FOLDER)
         for file in os.listdir(TEST_FOLDER):
             file_path = os.path.join(TEST_FOLDER, file)
-            assert oct(os.stat(file_path).st_mode)[-3:] == "644"
+            assert oct(os.stat(file_path).st_mode)[-3:] == EXPECTED_PERM
     finally:
         shutil.rmtree(TEST_FOLDER)
         pass

--- a/utils/file_permissions.py
+++ b/utils/file_permissions.py
@@ -1,3 +1,11 @@
+"""
+Helper module for changing file permissions.
+
+Functions:
+    restrict_file_permissions(folder_path: str) -> None
+"""
+
+
 import os
 import stat
 
@@ -5,7 +13,7 @@ import stat
 PERMISSIONS = 0o644
 
 
-def restrict_file_permissions(folder_path: str):
+def restrict_file_permissions(folder_path: str) -> None:
     """
     Set file permissions to read-write for owner, read for group and others.
     Intended for use on folders containing files uploaded by application users.

--- a/utils/file_permissions.py
+++ b/utils/file_permissions.py
@@ -18,5 +18,5 @@ def restrict_file_permissions(folder_path: str):
         if not os.path.exists(file_path):
             raise FileNotFoundError(f"File {file_path} does not exist")
         current_permissions = os.stat(file_path).st_mode
-        new_permissions = current_permissions | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+        new_permissions = stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
         os.chmod(file_path, new_permissions)

--- a/utils/file_permissions.py
+++ b/utils/file_permissions.py
@@ -1,0 +1,22 @@
+import os
+import stat
+
+
+PERMISSIONS = 0o644
+
+
+def restrict_file_permissions(folder_path: str):
+    """
+    Set file permissions to read-write for owner, read for group and others.
+    Intended for use on folders containing files uploaded by application users.
+
+    Args:
+        folder_path (str): path to folder containing files to be restricted
+    """
+    for file in os.listdir(folder_path):
+        file_path = os.path.join(folder_path, file)
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"File {file_path} does not exist")
+        current_permissions = os.stat(file_path).st_mode
+        new_permissions = current_permissions | stat.S_IRUSR | stat.S_IWUSR | stat.S_IRGRP | stat.S_IROTH
+        os.chmod(file_path, new_permissions)


### PR DESCRIPTION
Added functionality to restrict execute file permissions on files uploaded by users:
- user (server) process has read-write permissions
- group and others have read only permission